### PR TITLE
Restore support for ENET_HOST_ANY

### DIFF
--- a/include/enet6/enet.h
+++ b/include/enet6/enet.h
@@ -86,13 +86,20 @@ typedef struct _ENetAddress
 {
    ENetAddressType type;
    enet_uint16 port;
-   union 
+   union Host
    {
        enet_uint8 v4[4];
        enet_uint16 v6[8];
+       enet_uint32 v4_uint32;
+
+       Host& operator=(enet_uint32 value) {
+          v4_uint32 = value;
+          return *this;
+       }
    } host;
 } ENetAddress;
 
+#define ENET_HOST_ANY       0
 #define ENET_PORT_ANY       0
 
 /**


### PR DESCRIPTION
ENetAddress::host is now a union instance, so it can't be initialized by constants like ENET_HOST_ANY. I named the union "Host" and then gave it an assignment operator to restore this type of initialization. I then defined ENET_HOST_ANY again. This can be improved upon (like by adding enet_uint64 to types.h and to this union, and then adding overloads or templating to the assignment operator so that the correct union member is assigned to based on the input type or whatever)