### PR TITLE
Improved Android Support

### DIFF
--- a/src/unix.c
+++ b/src/unix.c
@@ -53,7 +53,7 @@
 #include <poll.h>
 #endif
 
-#if !defined(HAS_SOCKLEN_T) && !defined(__socklen_t_defined)
+#if !defined(HAS_SOCKLEN_T) && !defined(__socklen_t_defined) && !defined(__ANDROID__)
 typedef int socklen_t;
 #endif
 


### PR DESCRIPTION
It appears that Android's NDK already defines `socklen_t` as `unsigned int`, and this line throws a compilation when building for Android:

../enet6/unix.c:57:13: error: typedef redefinition with different types ('int' vs '__socklen_t' (aka 'unsigned int')) 57 | typedef int socklen_t;

../Android/Sdk/ndk/27.0.12077973/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/include/sys/types.h:117:21: note: previous definition is here
117 | typedef __socklen_t socklen_t;

I have added a check to improve support for Android devices.